### PR TITLE
Fetch essay and article timestamps

### DIFF
--- a/src/site/_data/meta.js
+++ b/src/site/_data/meta.js
@@ -57,6 +57,8 @@ module.exports = async (data) => {
     timestampFormat: process.env.TIMESTAMP_FORMAT || "MMM dd, yyyy h:mm a",
     showCreated: process.env.SHOW_CREATED_TIMESTAMP ? process.env.SHOW_CREATED_TIMESTAMP == "true" : true,
     showUpdated: process.env.SHOW_UPDATED_TIMESTAMP ? process.env.SHOW_UPDATED_TIMESTAMP == "true" : true,
+    createdFrontmatterKey: process.env.CREATED_TIMESTAMP_FRONTMATTER_KEY || "dg-created",
+    updatedFrontmatterKey: process.env.UPDATED_TIMESTAMP_FRONTMATTER_KEY || "dg-updated",
   };
   const meta = {
     env: process.env.ELEVENTY_ENV,


### PR DESCRIPTION
Add support for reading created/updated timestamps from frontmatter keys to allow explicit publish date definition.

This change introduces a new timestamp resolution order: frontmatter keys (`dg-created`/`dg-updated` or custom env keys) are now prioritized, followed by `created`/`updated` frontmatter fields, before falling back to git history and filesystem timestamps.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d284f57-3e5c-4acc-8bee-d23ca483be7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d284f57-3e5c-4acc-8bee-d23ca483be7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

